### PR TITLE
Use older Azure SDK for CentOS 7 cloud tests

### DIFF
--- a/cloud-only/azure.sls
+++ b/cloud-only/azure.sls
@@ -3,7 +3,12 @@ include:
 
 azure:
   pip.installed:
-    {%- if salt['config.get']('virtualenv_path', None)  %}
+    {%- if (grains['os'] != 'CentOS' %}
+    - name: azure==0.8.3
+    {%- else %}
+    - name: azure
+    {%- endif %}
+    {%- if salt['config.get']('virtualenv_path', None) %}
     - bin_env: {{ salt['config.get']('virtualenv_path') }}
     {%- endif %}
     - require:


### PR DESCRIPTION
azure 0.10.0 is failing to pip install on CentOS7 images,
but appears to be fine on Ubuntu 14.04.
